### PR TITLE
Agrega Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:argon
+
+WORKDIR /edca-dashboard
+
+ADD . /edca-dashboard
+
+RUN npm install
+
+EXPOSE 4000
+
+CMD ["./bin/www"]


### PR DESCRIPTION
Para construir el contenedor:

```docker build -t mxabierto/edca-dashboard . ```

Para correrlo:

```docker run --name edca-dashboard -p 4000:4000 -d mxabierto/edca-dashboard ```